### PR TITLE
Fix 'name' key not found and build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,3 +245,5 @@ target_link_libraries(Tests${PROJECT_NAME} PUBLIC
   CLI11::CLI11 # command line parser
   Catch2::Catch2 # Unit test framework
 )
+
+target_link_options(Tests${PROJECT_NAME} PRIVATE "-Wl,--allow-multiple-definition")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ Building
     conda env update --file conda_contesse.yaml
     conda activate contess
     ```
-2. Build the code
+2. Install additional packages
+   ```
+   sudo apt-get install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxxf86vm-dev
+   ```
+3. Setup ContesseUtils
+   ```
+   cd py/
+   pip install -e .
+   cd ..
+   ```
+4. Build the code
     ```bash
     mkdir build && cd build
     cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/py/ContessUtils/TestLauncher.py
+++ b/py/ContessUtils/TestLauncher.py
@@ -25,6 +25,7 @@ class TestSpec:
         if '.json' in os.path.splitext(spec_file):
             try:
                 spec = json.loads(spec_file.read_text())
+                spec['pipeline_test_cases'] = [str(spec_file.name)]
             except Exception as e:
                 raise ContessException(
                     f'Could not read file {spec_file}') from e

--- a/py/ContessUtils/TestLauncher.py
+++ b/py/ContessUtils/TestLauncher.py
@@ -30,7 +30,7 @@ class TestSpec:
                 raise ContessException(
                     f'Could not read file {spec_file}') from e
         else:
-            spec = {'pipeline_test_cases': [str(spec_file.name)]}
+            spec = {'pipeline_test_cases': ['../data/json/pipeline/' + str(spec_file.name) + '.json']}
         if not cpp_exe.exists():
             raise ContessException(f'Could not find cpp executable {cpp_exe}')
 


### PR DESCRIPTION
On Ubuntu 22, I was not able to build the code before bringing some changes to the CMakeLists.txt.

I also clarified some missing steps in the README, such as the need of additional dependencies, and the installation of the local pip package `ContesseUtils`.

I experienced issues running
```bash
python3 ../py/scripts/run_model.py ../data/json/pipeline/torus_quad_v1.json ./TestsContourTessellation --out out
``` 

which was fixed by adding this line: `spec['pipeline_test_cases'] = [str(spec_file.name)]`. 


I'm still, however, having an issue with this line 

```bash
 python3 ../py/scripts/run_model.py car ./TestsContourTessellation --out out
Running basic_pipeline:car `python3 /home/cedric/ConTesse/py/ContessUtils/Pipeline.py /home/cedric/ConTesse/build/.tmp/a13a2ea4c2fc4ec58cff75177503f62e/spec.json /home/cedric/ConTesse/build/TestsContourTessellation basic_pipeline:car --xml /home/cedric/ConTesse/build/.tmp/a13a2ea4c2fc4ec58cff75177503f62e/output.xml --out /home/cedric/ConTesse/build/out`
Num success = 0
Num failure = 1
=========================================
name=car, success=False
Exception happened. Code failed.
Traceback (most recent call last):
  File "../py/scripts/run_model.py", line 266, in <module>
    Async.run_async_entry_point(main())
  File "/home/cedric/ConTesse/py/ContessUtils/Async.py", line 59, in run_async_entry_point
    return asyncio.get_event_loop().run_until_complete(coroutine)
  File "/home/cedric/anaconda3/envs/contesse/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "../py/scripts/run_model.py", line 184, in main
    mesh_open = [l for l in result.out if 'Input mesh' in l][0]
IndexError: list index out of range
```

